### PR TITLE
Use published chart instead of GitHub source yaml

### DIFF
--- a/src/mybinder-upgrades/henchbot.py
+++ b/src/mybinder-upgrades/henchbot.py
@@ -336,8 +336,8 @@ class henchBotMyBinder:
         '''
         Get the latest bhub SHA from the helm chart
         '''
-        # Load latest binderhub and jupyterhub commits
-        url_helm_chart = 'https://raw.githubusercontent.com/jupyterhub/helm-chart/gh-pages/index.yaml'
+        # Load latest published binderhub and jupyterhub commits
+        url_helm_chart = 'https://jupyterhub.github.io/helm-chart/index.yaml'
         helm_chart_yaml = load(requests.get(url_helm_chart).text)
 
         updates_sorted = sorted(


### PR DESCRIPTION
There may be a delay between updating a GitHub pages branch and the result being pushed to the live website. This uses the published GitHub pages `index.yaml` instead of fetching it from the GitHub repo.

See https://github.com/jupyterhub/mybinder.org-deploy/issues/1706