### PR TITLE
Add missing argument to `delete_old_branch()` call

### DIFF
--- a/src/mybinder-upgrades/henchbot.py
+++ b/src/mybinder-upgrades/henchbot.py
@@ -115,7 +115,7 @@ class henchBotMyBinder:
         '''
         if not existing_pr:
             if self.fork_exists:  # fork exists for other repo and old branch for this repo
-                self.delete_old_branch()
+                self.delete_old_branch(repo)
                 subprocess.check_call(
                     ['git', 'pull', 'https://github.com/jupyterhub/mybinder.org-deploy.git', 'master'])
             subprocess.check_call(


### PR DESCRIPTION
I think what happened is that there is a open PR to uprgade the Binderhub version and now a change in repo2docker happened. This means henchbot will open a second PR to deal with the repo2docker upgrade. Because this situation (two PRs at the same time) doesn't happen very often we are hitting a bit of code where a method is being called with a missing argument. This PR adds that argument. If it doesn't fix it, we need to dive a bit deeper into the debugging universe.

This is the log from a heroku run:

```
2021-01-24T16:21:32.765061+00:00 app[scheduler.6290]: Fetching latest commit SHA for BinderHub and repo2docker...
2021-01-24T16:21:32.865246+00:00 app[scheduler.6290]: repo2docker 0.11.0-207.g45229ad 2021.01.0
2021-01-24T16:21:34.840423+00:00 app[scheduler.6290]: binderhub 0.2.0-n472.h32e06ee 0.2.0-n499.h81660eb
2021-01-24T16:21:35.238098+00:00 app[scheduler.6290]: Cloning into 'mybinder.org-deploy'...
2021-01-24T16:21:35.994341+00:00 app[scheduler.6290]: Traceback (most recent call last):
2021-01-24T16:21:35.994363+00:00 app[scheduler.6290]:   File "src/mybinder-upgrades/henchbot.py", line 369, in <module>
2021-01-24T16:21:35.994733+00:00 app[scheduler.6290]:     hb.update_repos(['repo2docker', 'binderhub'])
2021-01-24T16:21:35.994749+00:00 app[scheduler.6290]:   File "src/mybinder-upgrades/henchbot.py", line 45, in update_repos
2021-01-24T16:21:35.994881+00:00 app[scheduler.6290]:     self.upgrade_repo_commit(existing_pr, repo)
2021-01-24T16:21:35.994897+00:00 app[scheduler.6290]:   File "src/mybinder-upgrades/henchbot.py", line 217, in upgrade_repo_commit
2021-01-24T16:21:35.995052+00:00 app[scheduler.6290]:     self.checkout_branch(existing_pr, repo)
2021-01-24T16:21:35.995068+00:00 app[scheduler.6290]:   File "src/mybinder-upgrades/henchbot.py", line 118, in checkout_branch
2021-01-24T16:21:35.995199+00:00 app[scheduler.6290]:     self.delete_old_branch()
2021-01-24T16:21:35.995226+00:00 app[scheduler.6290]: TypeError: delete_old_branch() missing 1 required positional argument: 'repo'
```